### PR TITLE
Merge hotfix/late-pity-system into Main

### DIFF
--- a/simulation_sequential.cpp
+++ b/simulation_sequential.cpp
@@ -115,7 +115,7 @@ int main(int argc, char* argv[]) {
     }
     else {
       pity_count++;
-      if (pity_count > pity_starting_point) {
+      if (pity_count >= pity_starting_point) {
         star6_threshold += delta_star6_threshold;
         target_star6_threshold += delta_target_star6_threshold;
       }


### PR DESCRIPTION
Fixed a severe bug..
* Bug detail: The pity system will start one-pull-late compared with the setting value of `-p` or `--pity` command line argument.
For example, the pity system will actually come into effect at 52nd pull (52nd pull has a raise probability) while provided with `-p 50` command line argument - it supposed to be effect on 51st pull (51st pull should have a raised probability)
All simulations need to be re-run, although this may not have a obvious influence on the final result.